### PR TITLE
Fix major bugs related to Pareto table and make new additions to pareto graphs

### DIFF
--- a/bd/tabela_pareto.py
+++ b/bd/tabela_pareto.py
@@ -93,13 +93,13 @@ class pareto:
                     tabela['No. Ocorrências'] = tabela.groupby('Ocorrências')['Ocorrências'].transform('count')
                     tabela.drop_duplicates(subset='Ocorrências', keep='first', inplace=True)
                     
-                    tabela = tabela.sort_values(by=['No. Ocorrências'],ascending=False)
-                    
                     tabela['Custo Total'] = tabela['Custo Un.'] * tabela['No. Ocorrências']
                     
                     tabela['Freq. Relativa'] = tabela['No. Ocorrências'] / tabela['No. Ocorrências'].sum() * 100
                     
                     tabela['Freq. Acumulada'] = tabela['Freq. Relativa'].cumsum()/tabela['Freq. Relativa'].sum() * 100
+                    
+                    tabela = tabela.sort_values(by=['Custo Total'],ascending=False)
                     
                     matplot = tabela[:].copy()
                     

--- a/bd/tabela_pareto.py
+++ b/bd/tabela_pareto.py
@@ -106,7 +106,7 @@ class pareto:
                     total_ocorrencias = tabela['No. Ocorrências'].sum()
                     total_custos_unitarios = tabela['Custo Un.'].sum()
                     total_custos = tabela['Custo Total'].sum()
-                    matplot.loc[-1] = ['Total', total_ocorrencias, total_custos_unitarios, total_custos, np.nan, np.nan]
+                    matplot.loc[-1] = ['Total', total_ocorrencias, total_custos_unitarios, np.nan, np.nan, np.nan]
                     
                     tabela["Freq. Acumulada"] = to_numeric(tabela["Freq. Acumulada"], errors='coerce')
                     tabela["Freq. Relativa"] = tabela["Freq. Relativa"].round(2).apply(lambda x: f"{x:.2f}%")

--- a/bd/tabela_pareto.py
+++ b/bd/tabela_pareto.py
@@ -95,11 +95,11 @@ class pareto:
                     
                     tabela['Custo Total'] = tabela['Custo Un.'] * tabela['No. Ocorrências']
                     
-                    tabela['Freq. Relativa'] = tabela['No. Ocorrências'] / tabela['No. Ocorrências'].sum() * 100
+                    tabela = tabela.sort_values(by=['Custo Total'],ascending=False)
+                    
+                    tabela['Freq. Relativa'] = tabela['Custo Total'] / tabela['Custo Total'].sum() * 100
                     
                     tabela['Freq. Acumulada'] = tabela['Freq. Relativa'].cumsum()/tabela['Freq. Relativa'].sum() * 100
-                    
-                    tabela = tabela.sort_values(by=['Custo Total'],ascending=False)
                     
                     matplot = tabela[:].copy()
                     

--- a/telas/app.py
+++ b/telas/app.py
@@ -161,7 +161,13 @@ class Tela:
             '''
             is_saved = edit_config.getIsSaved()
             if is_saved == 'True':
-                pass
+                if command == 'Fechar':
+                        apagar_dados()
+                        tela_login.destroy()
+                elif command == 'Sair':
+                    apagar_dados('Sair')
+                    self.janela.destroy()
+                    tela_login.deiconify()
             else:
                 confirmar = dialogs.MessageDialog(parent=self.instancia_com_tabela.home,
                                                 title="Tabela já existente",
@@ -179,13 +185,13 @@ class Tela:
                     if confirmar.result == 'Sim':
                         saves.save()
                         
-                if command == 'Fechar':
-                    apagar_dados()
-                    tela_login.destroy()
-                elif command == 'Sair':
-                    apagar_dados('Sair')
-                    self.janela.destroy()
-                    tela_login.deiconify()
+                    if command == 'Fechar':
+                        apagar_dados()
+                        tela_login.destroy()
+                    elif command == 'Sair':
+                        apagar_dados('Sair')
+                        self.janela.destroy()
+                        tela_login.deiconify()
             
             
                 

--- a/telas/telainicial.py
+++ b/telas/telainicial.py
@@ -324,17 +324,37 @@ class inicio:
             fig,ax1 = plt.subplots(figsize=(15,10))
 
             ax1.set_title('Pareto')
+            
+            try:
+                ax1.set_ylabel('Custo',color=color1)
+                
+                ax1.bar(matplot['Ocorrências'], matplot['Custo Total'], color=color1, edgecolor='orange', linewidth=2)
 
-            ax1.set_ylabel('Frequência (%)',color=color1)
+                ax1.tick_params(axis = 'y', labelcolor = color1)
+                
+                for i, valor in enumerate(matplot['Custo Total']):
+                    ax1.annotate(f'R$ {valor:.2f}', (i, valor))
+                
+                ax2 = ax1.twinx()
+                ax2.set_ylabel('%', color=color2)
 
-            ax1.bar(matplot['Ocorrências'], matplot['Freq. Relativa'], color=color1, edgecolor='orange', linewidth=2)
+                ax2.plot(matplot['Ocorrências'], matplot['Freq. Acumulada'], color = color2, marker = 's', markersize = 8, linestyle = '-')
 
-            ax1.tick_params(axis = 'y', labelcolor = color1)
+            except Exception as e:
 
-            ax2 = ax1.twinx()
-            ax2.set_ylabel('%', color=color2)
+                ax1.set_ylabel('Frequência (%)',color=color1)
+                
+                ax1.bar(matplot['Ocorrências'], matplot['Freq. Relativa'], color=color1, edgecolor='orange', linewidth=2)
 
-            ax2.plot(matplot['Ocorrências'], matplot['Freq. Acumulada'], color = color2, marker = 's', markersize = 8, linestyle = '-')
+                ax1.tick_params(axis = 'y', labelcolor = color1)
+                
+                for i, valor in enumerate(matplot['Freq. Relativa']):
+                    ax1.annotate(f'{valor:.2f} %', (i, valor))
+                
+                ax2 = ax1.twinx()
+                ax2.set_ylabel('%', color=color2)
+
+                ax2.plot(matplot['Ocorrências'], matplot['Freq. Acumulada'], color = color2, marker = 's', markersize = 8, linestyle = '-')
 
             ax2.tick_params(axis='y',labelcolor=color2)
             ax2.set_ylim([0,120])


### PR DESCRIPTION
### **fix 1: app won't close when already saved.**
App wouldn't close if the tables where already saved because there was no calling to close function.

### **fix 2 and 4: app sortes not-null cost tables by total cost, calculation of freq when sort by cost.**
These 2 are related. First, app where sorting tables with not-null cost by occurrence counts, which should be only for cost null tables. Second, cost sorting must be done before calculating relative and cumulative frequencies in order to get the right data.

### **fix 3: removes total cost from graphics dataframe.**
This had a problem with graph which would create a "Total" bar which shouldn't exist. So I set the sum of Total Cost Null to avoid this problem.

### **graph update**

- Distinguish cost null tables and not null cost tables.

- Added annotations to bars (% of relative freq. for cost null tables, $ of Total cost per item on not null cost tables)